### PR TITLE
Close tctx config file after reading

### DIFF
--- a/config/manager.go
+++ b/config/manager.go
@@ -132,6 +132,7 @@ func (t *ConfigManager) GetActiveContextName() (string, error) {
 // GetAllContexts returns the ClusterConfig for all configured contexts
 func (t *ConfigManager) GetAllContexts() (*Config, error) {
 	file, err := os.Open(t.configFilePath)
+	defer file.Close()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When reading the context file with GetAllContexts, the file is never closed