### PR TITLE
Fix bug with overwriting nested configuration

### DIFF
--- a/config/manager.go
+++ b/config/manager.go
@@ -170,7 +170,30 @@ func (t *ConfigManager) UpsertContext(name string, new *ClusterConfig) error {
 			existing.DataConverter = new.DataConverter
 		}
 		if new.TLS != nil {
-			existing.TLS = new.TLS
+
+			if new.TLS.CertPath != "" {
+				existing.TLS.CertPath = new.TLS.CertPath
+			}
+
+			if new.TLS.KeyPath != "" {
+				existing.TLS.KeyPath = new.TLS.KeyPath
+			}
+
+			if new.TLS.CACertPath != "" {
+				existing.TLS.CACertPath = new.TLS.CACertPath
+			}
+
+			if new.TLS.ServerName != "" {
+				existing.TLS.ServerName = new.TLS.ServerName
+			}
+
+			// This one is tricky. It'll basically always be false in this operation unless the
+			// user explicitly sets it to true on the command line due to Go's "defaults".
+			// In order to properly track this, there likely needs to be a different type to
+			// represent the options specified on the command line *or* the Config type needs to be
+			// pointers, where a nil option represents "unchanged"
+			existing.TLS.DisableHostVerification = new.TLS.DisableHostVerification
+
 		}
 		if new.Environment != nil {
 			if existing.Environment == nil {

--- a/main_test.go
+++ b/main_test.go
@@ -47,10 +47,11 @@ func TestCLI(t *testing.T) {
 	// Validate new list output
 	c.Run(t, TestCase{
 		Command: "list",
-		StdOut: `
-NAME          ADDRESS                     NAMESPACE    WEB                                                 STATUS
-localhost     localhost:7233              default
-production    temporal.example.com:443    myapp        http://localhost:8080/namespaces/myapp/workflows    active`,
+		StdOutContains: []string{
+			"NAME          ADDRESS                     NAMESPACE    WEB                                                 STATUS",
+			"localhost     localhost:7233              default",
+			"production    temporal.example.com:443    myapp        http://localhost:8080/namespaces/myapp/workflows    active",
+		},
 	})
 	// Check that environment variables are correctly set
 	c.Run(t, TestCase{
@@ -211,6 +212,7 @@ func (f tctxConfigFile) newApp() (*cli.App, *bytes.Buffer) {
 }
 
 func (f tctxConfigFile) Run(t *testing.T, tc TestCase) {
+	t.Helper()
 	app, buf := f.newApp()
 	err := app.Run(append([]string{"tctx"}, strings.Split(tc.Command, " ")...))
 
@@ -235,6 +237,7 @@ func (f tctxConfigFile) Run(t *testing.T, tc TestCase) {
 }
 
 func assertOutput(t *testing.T, expected, actual string) {
+	t.Helper()
 	expected = strings.TrimSpace(expected)
 	actual = strings.TrimSpace(actual)
 	if expected != "" && expected != actual {


### PR DESCRIPTION
This patch fixes a bug (although not perfectly) in the `update`
subcommand. Since the config passed to `config:Upsert` *always* has
a non-nil `TLS` property (filled with default values, which means
`false` and empty strings), we need to, at the very least, check each
nested property to see if the values sent are non-empty.

Without this patch, changing *any* config option would wipe out the TLS
settings. See the regression test introduced in an earlier commit.

Note that this is still not quite perfect: it will still "reset" the
value of "disable host key verification" which isn't as problematic
since the default of `false` is the safer option.

A proper fix would likely involve changing the `Config` struct to use
pointers (so we can disambiguate between unset and empty) or an
alternate datatype to hold "updates" (such as a map), passed to the
`Upsert` function, or simply a slice of field names that were supplied
on the command line which are used to filter updates to the context.